### PR TITLE
🐛 fix(common): copy cycle timestamp into aggregate payout summary

### DIFF
--- a/common/payouts.go
+++ b/common/payouts.go
@@ -510,6 +510,7 @@ func (summary *PayoutSummary) AddCycleSummary(cycle int64, another *CyclePayoutS
 	slices.Sort(summary.Cycles)
 	summary.CycleSummaries[cycle] = *another
 
+	summary.Timestamp = another.Timestamp
 	summary.OwnStakedBalance = summary.OwnStakedBalance.Add(another.OwnStakedBalance)
 	summary.OwnDelegatedBalance = summary.OwnDelegatedBalance.Add(another.OwnDelegatedBalance)
 	summary.ExternalStakedBalance = summary.ExternalStakedBalance.Add(another.ExternalStakedBalance)


### PR DESCRIPTION
AddCycleSummary aggregated every CyclePayoutSummary field into the top-level PayoutSummary except Timestamp, which stayed at its zero value. Notificators (e.g. Slack) print summary.Timestamp, so payout notifications showed 0001-01-01T00:00:00Z instead of the actual run time.